### PR TITLE
Implement flash attention with padding fix

### DIFF
--- a/tests/layers/research/flash_attention_test.py
+++ b/tests/layers/research/flash_attention_test.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+"""Tests for flash_attention."""
+
+import numpy as np
+from absl.testing import absltest
+
+import jax
+from trax import fastmath
+from trax.fastmath import numpy as jnp
+from trax.layers.research import flash_attention
+
+
+def _naive_attention(q, k, v, mask=None):
+    logits = jnp.einsum("bqd,bkd->bqk", q, k)
+    if mask is not None:
+        logits = jnp.where(mask[:, None, :], -1e9, logits)
+    weights = jax.nn.softmax(logits, axis=-1)
+    return jnp.einsum("bqk,bkd->bqd", weights, v)
+
+
+class FlashAttentionTest(absltest.TestCase):
+    def test_matches_naive(self):
+        with fastmath.use_backend(fastmath.Backend.JAX):
+            batch, seqlen, d = 2, 7, 4
+            q = jnp.arange(batch * seqlen * d).reshape((batch, seqlen, d)) / 100.0
+            k = jnp.arange(batch * seqlen * d).reshape((batch, seqlen, d)) / 50.0
+            v = jnp.arange(batch * seqlen * d).reshape((batch, seqlen, d)) / 25.0
+            mask = jnp.arange(seqlen)[None, :] >= 5
+            out_ref = _naive_attention(q, k, v, mask)
+            out_flash = flash_attention.flash_attention(
+                q, k, v, block_size=4, mask=mask
+            )
+            self.assertEqual(out_ref.shape, out_flash.shape)
+            np.testing.assert_allclose(out_ref, out_flash, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/trax/layers/research/__init__.py
+++ b/trax/layers/research/__init__.py
@@ -13,3 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Research layers."""
+
+from . import flash_attention  # noqa: F401

--- a/trax/layers/research/flash_attention.py
+++ b/trax/layers/research/flash_attention.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+"""Flash attention implementation for Trax."""
+
+import jax
+from jax import lax
+import jax.numpy as jnp
+
+
+def flash_attention(q, k, v, *, block_size, mask=None):
+    """Memory efficient dot-product attention.
+
+    Args:
+      q: Queries array of shape [batch, len, depth].
+      k: Keys array of shape [batch, len, depth].
+      v: Values array of shape [batch, len, depth_v].
+      block_size: Integer block size used for computation.
+      mask: Optional boolean mask of shape [batch, len] where ``True`` values
+        indicate positions that should be masked out.
+
+    Returns:
+      Array of shape [batch, len, depth_v] with the attention outputs.
+    """
+    seqlen = q.shape[1]
+    pad_len = (block_size - seqlen % block_size) % block_size
+    if pad_len:
+        pad = ((0, 0), (0, pad_len), (0, 0))
+        q = jnp.pad(q, pad)
+        k = jnp.pad(k, pad)
+        v = jnp.pad(v, pad)
+        if mask is not None:
+            mask = jnp.pad(mask, ((0, 0), (0, pad_len)), constant_values=True)
+    total_len = q.shape[1]
+
+    if mask is not None:
+        mask_b = mask[:, None, :]
+    else:
+        mask_b = None
+
+    outputs = []
+    for start in range(0, total_len, block_size):
+        q_block = lax.dynamic_slice(q, (0, start, 0), (q.shape[0], block_size, q.shape[2]))
+        logits = jnp.einsum("bqd,bkd->bqk", q_block, k)
+        if mask_b is not None:
+            logits = jnp.where(mask_b, -1e9, logits)
+        weights = jax.nn.softmax(logits, axis=-1)
+        out_block = jnp.einsum("bqk,bkd->bqd", weights, v)
+        outputs.append(out_block)
+    output = jnp.concatenate(outputs, axis=1)
+    if pad_len:
+        output = output[:, :seqlen, :]
+    return output


### PR DESCRIPTION
## Summary
- add `flash_attention` layer that pads inputs to multiples of block_size
- trim padded outputs to original length
- test flash attention against naive reference implementation

## Testing
- `pytest -q tests/layers/research/flash_attention_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6854870a3510832fb8995bbda4ce704d